### PR TITLE
Set MQTT settings from values retrieved from the RoboHome API

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,22 +20,19 @@ Most of these can be downloaded from the Library Manager in the Ardunio IDE.  If
 ### Configuring :wrench:
 
 - Set values for all the variables at the top of the `RoboHome.ino` file to connect to your:
-    - WiFi SSID and password
-    - MQTT account (also in your RoboHome-Web `.env` file)
-        - The topic should fit the pattern `RoboHome/<user_id>/+` where:
-            - `RoboHome` is the top level topic to help distingish RoboHome traffic from other traffic on the MQTT account
-            - `user_id` is the value for the [`user_id` field in the `users` table in the RoboHome-Web project](https://github.com/dbudwin/RoboHome-Web/blob/master/app/User.php) you want to control
-            - `+` is a wildcard to match a single level
-    - RoboHome-Web application URL and SSL/TLS SHA1 fingerprint
+    - WiFi SSID and password.
+    - RoboHome-Web application URL and SSL/TLS SHA1 fingerprint.
         - This can be found using Chrome's Developer Tools.  Click "Security," "View certificate," expand "Details," scroll to the "Fingerprints" section.  Copy the "SHA-1" value including spaces.
-        - The value for `robohomeWebSha1Fingerprint` is likely to change whenever your SSL/TLS certificate gets renewed.  For [Let's Encrypt](https://www.letsencrypt.org/) users, the default is every 3 months.
+        - The value for `ROBOHOME_SHA1_FINGERPRINT` is likely to change whenever your SSL/TLS certificate gets renewed.  For [Let's Encrypt](https://www.letsencrypt.org/) users, the default is every 3 months.
+    - RoboHome-Web username and password used to log in to the RoboHome website.
+    - RoboHome-Web password grant details provided when running the `php artisan passport:install` command on the RoboHome-Web installation, the needed values will be located under the heading "Password grant client created successfully."  If you have previously executed this command on the server, it is possible to look in the `oauth_clients` table to retrieve the values.
 
 ### How To Contribute :gift:
 
-Contributions are always welcome!  Please fork this repo and open a PR with your code or feel free to make an issue.  All PRs will need to be reviewed and pass automated checks.  If feedback is given on a PR, please submit updates to the original PR in the form of [fixup! commits](https://robots.thoughtbot.com/autosquashing-git-commits) which will later be squashed before the PR is merged.
+Contributions are always welcome!  Please fork this repo and open a pull request with your code or feel free to make an issue.  All pull requests will need to be reviewed and pass automated checks.  If feedback is given on a pull request, please submit updates to the original PR in the form of [fixup! commits](https://robots.thoughtbot.com/autosquashing-git-commits) which will later be squashed before the pull request is merged.
 
 This repo supports the principles of [Bob Martin's Clean Code](http://www.goodreads.com/book/show/3735293-clean-code).
 
 ### Notes :notebook:
 
-The ESP8266 is a fairly weak computer which is why it is necessary to include the SSL/TLS certificate, otherwise it would be unable to connect to an HTTPS website which is required for the RoboHome-Web project.  Make sure the RoboHome-Web website the ESP8266 is connecting too uses the correct ciphers.  See the "Requirements" section of the RoboHome-Web README for up-to-date information for configuring the SSL/TLS certificate.
+The ESP8266 is a fairly weak computer which is why it is necessary to include the SHA1 fingerprint for the SSL/TLS certificate, otherwise it would be unable to connect to an HTTPS website which is required for the RoboHome-Web project.  Make sure the RoboHome-Web website the ESP8266 is connecting too uses the correct ciphers.  See the "Requirements" section of the [RoboHome-Web README](https://github.com/dbudwin/RoboHome-Web/blob/master/README.md) for up-to-date information for configuring the SSL/TLS certificate.


### PR DESCRIPTION
Use the new `/api/settings/mqtt` endpoint to get the MQTT server settings for the currently authenticated user.  This also now takes advantage of the secured `api/settings/info` endpoint which now requires an authenticated user to read from this endpoint.