### PR TITLE
Set MQTT topic from values retrieved from the RoboHome API

### DIFF
--- a/RoboHome/RoboHome.ino
+++ b/RoboHome/RoboHome.ino
@@ -13,7 +13,7 @@ const String ROBOHOME_PASSWORD = "";
 const String ROBOHOME_PASSWORD_GRANT_CLIENT_SECRET = "";
 const int ROBOHOME_PASSWORD_GRANT_CLIENT_ID = 2;
 
-const char* mqttTopic = "RoboHome/1/+";
+const char* mqttTopic = "";
 const char* mqttUser = "";
 const char* mqttPassword = "";
 
@@ -115,6 +115,7 @@ void setMqttSettings() {
         const unsigned int mqttPort = 17431; // To use json["mqtt"]["tlsPort"]; the PubSubClient needs to support TLS first
         mqttUser = json["mqtt"]["user"];
         mqttPassword = json["mqtt"]["password"];
+        mqttTopic = json["mqtt"]["topic"];
 
         mqttClient.setServer(mqttServer, mqttPort);
         mqttClient.setCallback(mqttMessageReceivedCallback);


### PR DESCRIPTION
Use the new `/api/settings/mqtt` endpoint to also set the topic to subscribe to  listen to all devices for the currently authenticated user.

This is in response to this commit https://github.com/dbudwin/RoboHome-Web/pull/144/commits/5fc5f3632cc6dc34d369821342edf49be28ad369