### PR TITLE
Update to use public ID's for users and devices

### DIFF
--- a/RoboHome/RoboHome.ino
+++ b/RoboHome/RoboHome.ino
@@ -33,7 +33,7 @@ void setup() {
 
     ACCESS_TOKEN = getAccessToken();
 
-    setMqttSettings();
+    setMqttSettingsFromRoboHomeServer();
 }
 
 void loop() {
@@ -95,7 +95,7 @@ String getAccessToken() {
     }
 }
 
-void setMqttSettings() { 
+void setMqttSettingsFromRoboHomeServer() {
     RestClient restClient = RestClient(ROBOHOME_URL, 443, ROBOHOME_SHA1_FINGERPRINT);
 
     String authorizationBearerHeader = "Authorization: Bearer " + ACCESS_TOKEN;
@@ -153,9 +153,8 @@ String getBodyOfHttpRequestForDeviceInfo(char* topic, byte* payload, size_t leng
     restClient.setHeader(authorizationBearerHeader.c_str());
     restClient.setContentType("application/x-www-form-urlencoded");
 
-    String userId = getSectionFromString(topic, 1);
-    String deviceId = getSectionFromString(topic, 2);
-    String data = "userId=" + userId + "&action=" + message + "&deviceId=" + deviceId;
+    String publicDeviceId = getSectionFromString(topic, 2);
+    String data = "action=" + message + "&publicDeviceId=" + publicDeviceId;
     String response = "";
 
     unsigned int statusCode = restClient.post("/api/devices/info", data.c_str(), &response);


### PR DESCRIPTION
The microcontroller is now solely dependent on controlling and asking about users and devices based on the public ID's which are UUID's.  This adds a layer of security because it was previously using integer based ID's which are easy to guess and iterate through.  While still technically possible to guess UUID's, the odds are beyond astronomically small that it is not a worthwhile attack.

This completes the work done is RoboHome-Web pull requests:
https://github.com/dbudwin/RoboHome-Web/pull/144
https://github.com/dbudwin/RoboHome-Web/pull/145